### PR TITLE
Remove `org.mybatis:mybatis` to eliminate embedded `ognl:ognl` exposu…

### DIFF
--- a/CHANGES-WEBSPELLCHECKER.md
+++ b/CHANGES-WEBSPELLCHECKER.md
@@ -2,6 +2,12 @@
 
 This document records WebSpellChecker-specific changes on top of upstream LanguageTool.
 
+## 2025-09-19
+
+### Security
+- **MyBatis removal:** Removed `org.mybatis:mybatis` to eliminate embedded `ognl:ognl` exposure and address **CVE-2025-53192**.
+  - Scope: components depending on `org.mybatis:mybatis` (direct or transitive) packaging of `langtool/libs`.
+
 ## 2025-09-09
 
 ### Security

--- a/languagetool-standalone/src/main/assembly/zip.xml
+++ b/languagetool-standalone/src/main/assembly/zip.xml
@@ -57,6 +57,7 @@
                 <exclude>org.languagetool:languagetool-commandline</exclude>
                 <exclude>org.languagetool:languagetool-standalone</exclude>
                 <exclude>org.languagetool:languagetool-server</exclude>
+                <exclude>org.mybatis:mybatis</exclude>
             </excludes>
         </dependencySet>
         <dependencySet>


### PR DESCRIPTION
…re and address CVE-2025-53192