### PR TITLE
WP-7216: Security: upgrade opennlp-tools to 2.5.9 to address CVE-2026-42027, C…

### DIFF
--- a/CHANGES-WEBSPELLCHECKER.md
+++ b/CHANGES-WEBSPELLCHECKER.md
@@ -2,6 +2,12 @@
 
 This document records WebSpellChecker-specific changes on top of upstream LanguageTool.
 
+## 2026-05-09
+
+### Security
+- **OpenNLP upgrade:** Updated `opennlp-tools` to **2.5.9** to address **CVE-2026-42027**, **CVE-2026-40682** and **CVE-2026-42440**.
+  - Scope: components depending on `opennlp-tools` (direct or transitive) packaging of `langtool/libs`.
+
 ## 2026-05-07
 
 ### Security

--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@
         <org.apache.commons.commons-pool2.version>2.12.0</org.apache.commons.commons-pool2.version>
         <org.apache.commons.lang3.version>3.18.0</org.apache.commons.lang3.version>
         <org.apache.commons.text.version>1.12.0</org.apache.commons.text.version>
-        <org.apache.opennlp.opennlp-tools.version>1.9.4</org.apache.opennlp.opennlp-tools.version>
+        <org.apache.opennlp.opennlp-tools.version>2.5.9</org.apache.opennlp.opennlp-tools.version>
 
         <org.glassfish.jaxb.jaxb-runtime.version>4.0.5</org.glassfish.jaxb.jaxb-runtime.version>
         <org.ioperm.morphology-el.version>1.0.0</org.ioperm.morphology-el.version>


### PR DESCRIPTION
Docker Scout and AWS Inspector have flagged three vulnerabilities in opennlp-tools@1.9.4 used in the WProofreader Docker image (both arm64 and amd64):

CVE-2026-42027 (CRITICAL 9.8) — RCE via unsafe reflection in ExtensionLoader

CVE-2026-40682 (CRITICAL 9.1) — XXE via unsanitized dictionary parsing in DictionaryEntryPersistor

CVE-2026-42440 (HIGH 7.5) — OOM DoS via unbounded array allocation in AbstractModelReader

Update org.apache.opennlp.opennlp-tools.version from 1.9.4 to 2.5.9 in pom.xml. 