### PR TITLE
 Switch opennlp-tools to the com.webspellchecker fork to fix CVE-2026-40682, -42027, -42440

### DIFF
--- a/CHANGES-WEBSPELLCHECKER.md
+++ b/CHANGES-WEBSPELLCHECKER.md
@@ -2,6 +2,12 @@
 
 This document records WebSpellChecker-specific changes on top of upstream LanguageTool.
 
+## 2026-05-31
+
+### Security
+- **opennlp-tools fork:** Replaced `org.apache.opennlp:opennlp-tools:1.9.4` with the in-house fork `com.webspellchecker:opennlp-tools:1.9.4-webspellchecker-1` to address **CVE-2026-40682** (XXE in DictionaryEntryPersistor), **CVE-2026-42027** (unsafe reflection in ExtensionLoader), and **CVE-2026-42440** (DoS in AbstractModelReader). The fork backports the upstream fixes onto the 1.9.4 baseline. Upgrading to opennlp-tools 2.x is not viable because the chunker feature emission format changed (OPENNLP-1332) and breaks the legacy 1.5-format models used by LanguageTool.
+  - Scope: components depending on `opennlp-tools` (direct or transitive) packaging of `langtool/libs`.
+
 ## 2026-05-19
 
 ### Security

--- a/CHANGES-WEBSPELLCHECKER.md
+++ b/CHANGES-WEBSPELLCHECKER.md
@@ -6,6 +6,7 @@ This document records WebSpellChecker-specific changes on top of upstream Langua
 
 ### Security
 - **opennlp-tools fork:** Replaced `org.apache.opennlp:opennlp-tools:1.9.4` with the in-house fork `com.webspellchecker:opennlp-tools:1.9.4-webspellchecker-1` to address **CVE-2026-40682** (XXE in DictionaryEntryPersistor), **CVE-2026-42027** (unsafe reflection in ExtensionLoader), and **CVE-2026-42440** (DoS in AbstractModelReader). The fork backports the upstream fixes onto the 1.9.4 baseline. Upgrading to opennlp-tools 2.x is not viable because the chunker feature emission format changed (OPENNLP-1332) and breaks the legacy 1.5-format models used by LanguageTool.
+  - Fork repository: https://github.com/WebSpellChecker/opennlp.
   - Scope: components depending on `opennlp-tools` (direct or transitive) packaging of `langtool/libs`.
 
 ## 2026-05-19

--- a/languagetool-language-modules/en/pom.xml
+++ b/languagetool-language-modules/en/pom.xml
@@ -52,7 +52,7 @@
             <artifactId>opennlp-tokenize-models</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.opennlp</groupId>
+            <groupId>com.webspellchecker</groupId>
             <artifactId>opennlp-tools</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@
         <org.apache.commons.commons-pool2.version>2.12.0</org.apache.commons.commons-pool2.version>
         <org.apache.commons.lang3.version>3.18.0</org.apache.commons.lang3.version>
         <org.apache.commons.text.version>1.12.0</org.apache.commons.text.version>
-        <org.apache.opennlp.opennlp-tools.version>1.9.4-webspellchecker-1</org.apache.opennlp.opennlp-tools.version>
+        <com.webspellchecker.opennlp.opennlp-tools.version>1.9.4-webspellchecker-1</com.webspellchecker.opennlp.opennlp-tools.version>
 
         <org.glassfish.jaxb.jaxb-runtime.version>4.0.5</org.glassfish.jaxb.jaxb-runtime.version>
         <org.ioperm.morphology-el.version>1.0.0</org.ioperm.morphology-el.version>
@@ -677,7 +677,7 @@
             <dependency>
                 <groupId>com.webspellchecker</groupId>
                 <artifactId>opennlp-tools</artifactId>
-                <version>${org.apache.opennlp.opennlp-tools.version}</version>
+                <version>${com.webspellchecker.opennlp.opennlp-tools.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.carrot2</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@
         <org.apache.commons.commons-pool2.version>2.12.0</org.apache.commons.commons-pool2.version>
         <org.apache.commons.lang3.version>3.18.0</org.apache.commons.lang3.version>
         <org.apache.commons.text.version>1.12.0</org.apache.commons.text.version>
-        <org.apache.opennlp.opennlp-tools.version>1.9.4</org.apache.opennlp.opennlp-tools.version>
+        <org.apache.opennlp.opennlp-tools.version>1.9.4-webspellchecker-1</org.apache.opennlp.opennlp-tools.version>
 
         <org.glassfish.jaxb.jaxb-runtime.version>4.0.5</org.glassfish.jaxb.jaxb-runtime.version>
         <org.ioperm.morphology-el.version>1.0.0</org.ioperm.morphology-el.version>
@@ -426,16 +426,34 @@
                 <groupId>edu.washington.cs.knowitall</groupId>
                 <artifactId>opennlp-chunk-models</artifactId>
                 <version>${edu.washington.cs.knowitall.opennlp.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.opennlp</groupId>
+                        <artifactId>opennlp-tools</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>edu.washington.cs.knowitall</groupId>
                 <artifactId>opennlp-postag-models</artifactId>
                 <version>${edu.washington.cs.knowitall.opennlp.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.opennlp</groupId>
+                        <artifactId>opennlp-tools</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>edu.washington.cs.knowitall</groupId>
                 <artifactId>opennlp-tokenize-models</artifactId>
                 <version>${edu.washington.cs.knowitall.opennlp.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.opennlp</groupId>
+                        <artifactId>opennlp-tools</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>edu.washington.cs.knowitall</groupId>
@@ -657,7 +675,7 @@
                 <version>${lucene.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.opennlp</groupId>
+                <groupId>com.webspellchecker</groupId>
                 <artifactId>opennlp-tools</artifactId>
                 <version>${org.apache.opennlp.opennlp-tools.version}</version>
             </dependency>


### PR DESCRIPTION
## Summary

  Switches the `opennlp-tools` dependency from `org.apache.opennlp:opennlp-tools:1.9.4`
  to our in-house fork `com.webspellchecker:opennlp-tools:1.9.4-webspellchecker-1`,
  which backports fixes for three CVEs onto the 1.9.4 baseline.

  | CVE | Issue | Component |
  |-----|-------|-----------|
  | CVE-2026-40682 | XXE | DictionaryEntryPersistor |
  | CVE-2026-42027 | Unsafe reflection | ExtensionLoader |
  | CVE-2026-42440 | DoS | AbstractModelReader |

  Fork repository: https://github.com/WebSpellChecker/opennlp