### PR TITLE
WP-7315: fix(security): bump io.netty to 4.1.135.Final (CVE-2026-44249, -45416…

### DIFF
--- a/CHANGES-WEBSPELLCHECKER.md
+++ b/CHANGES-WEBSPELLCHECKER.md
@@ -2,6 +2,12 @@
 
 This document records WebSpellChecker-specific changes on top of upstream LanguageTool.
 
+## 2026-06-09
+
+### Security
+- **Netty upgrade:** Updated `io.netty` to **4.1.135.Final** to address **CVE-2026-44249**, **CVE-2026-45416**, **CVE-2026-45674** and **CVE-2026-47691**.
+  - Scope: components depending on `io.netty` (direct or transitive) packaging of `langtool/libs`.
+
 ## 2026-05-31
 
 ### Security

--- a/pom.xml
+++ b/pom.xml
@@ -1251,7 +1251,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.133.Final</version>
+                <version>4.1.135.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Upgrade bundled Netty to 4.1.135.Final in WProofreader image

Docker Scout flags a batch of HIGH CVEs, all in Netty 4.1.133.Final shipped inside webspellchecker/wproofreader:

CVE-2026-44249 (8.1) — IPv6 subnet filter bypass, netty-handler

CVE-2026-45416 (7.5) — SNIHandler memory exhaustion, netty-handler

CVE-2026-45674 (8.7) — DNS cache poisoning, netty-resolver-dns

CVE-2026-47691 (8.7) — DNS cache poisoning, netty-resolver-dns

All are fixed by a single dependency bump to Netty 4.1.135.Final (4.1.x line; 4.2.x equivalent is 4.2.15.Final), which also clears the other Netty CVEs in this scan.

Steps: pin Netty to 4.1.135.Final in the Java component that pulls it in, rebuild the image, rescan with Docker Scout to confirm zero remaining Netty findings.