### PR TITLE
security bump jackson-core to 2.18.7 (CWE-770)

### DIFF
--- a/CHANGES-WEBSPELLCHECKER.md
+++ b/CHANGES-WEBSPELLCHECKER.md
@@ -2,6 +2,12 @@
 
 This document records WebSpellChecker-specific changes on top of upstream LanguageTool.
 
+## 2026-06-12
+
+### Security
+- **jackson-core upgrade:** Updated `jackson-core` to **2.18.7** to address **CWE-770**.
+  - Scope: components depending on `jackson-core` (direct or transitive) packaging of `langtool/libs`.
+
 ## 2026-06-09
 
 ### Security

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
         <org.tukaani.version>1.10</org.tukaani.version>
 
         <guava.version>33.5.0-jre</guava.version>
-        <jackson.version>2.18.6</jackson.version>
+        <jackson.version>2.18.7</jackson.version>
         <lombok.version>1.18.34</lombok.version>
         <lucene.version>5.5.5</lucene.version>
         <morfologik.version>2.1.9</morfologik.version>


### PR DESCRIPTION
Upgrades com.fasterxml.jackson.core:jackson-core to 2.18.7 to address a high-severity CWE-770 (resource allocation without limits) vulnerability.

  Done by bumping the `jackson.version` property in the parent pom from 2.18.6 to 2.18.7, which updates both jackson-databind and the transitive jackson-core.

  Scope: components depending on jackson-core (direct or transitive) packaged in langtool/libs.