### PR TITLE
Security bump jackson-databind to 2.18.8 (CVE-2026-54513)

### DIFF
--- a/CHANGES-WEBSPELLCHECKER.md
+++ b/CHANGES-WEBSPELLCHECKER.md
@@ -2,6 +2,12 @@
 
 This document records WebSpellChecker-specific changes on top of upstream LanguageTool.
 
+## 2026-06-24
+
+### Security
+- **jackson-databind upgrade:** Updated `jackson-databind` to **2.18.8** to address **CVE-2026-54513**.
+  - Scope: components depending on `jackson-databind` (direct or transitive) packaging of `langtool/libs`.
+
 ## 2026-06-12
 
 ### Security

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
         <org.tukaani.version>1.10</org.tukaani.version>
 
         <guava.version>33.5.0-jre</guava.version>
-        <jackson.version>2.18.7</jackson.version>
+        <jackson.version>2.18.8</jackson.version>
         <lombok.version>1.18.34</lombok.version>
         <lucene.version>5.5.5</lucene.version>
         <morfologik.version>2.2.0</morfologik.version>


### PR DESCRIPTION
Security: bump jackson-databind to 2.18.8 to fix CVE-2026-54513 (HIGH, score 8.1) flagged by AWS Inspector on the wproofreader:6.13.1.0-arm64v8-base image. The BasicPolymorphicTypeValidator.allowIfSubTypeIsArray() allowlist could be  bypassed via an array's component type. Bumped the jackson.version property in pom.xml (2.18.7 → 2.18.8). https://nvd.nist.gov/vuln/detail/CVE-2026-54513