### PR TITLE
Security/cves 2026 jul

### DIFF
--- a/CHANGES-WEBSPELLCHECKER.md
+++ b/CHANGES-WEBSPELLCHECKER.md
@@ -7,6 +7,8 @@ This document records WebSpellChecker-specific changes on top of upstream Langua
 ### Security
 - **jackson-databind upgrade:** Updated `jackson-databind` to **2.18.9** to address **CVE-2026-54515**.
   - Scope: components depending on `jackson-databind` (direct or transitive) packaging of `langtool/libs`.
+- **ch.qos.logback upgrade:** Updated `ch.qos.logback` to **1.5.35** to address **CVE-2026-9828** and **CVE-2026-10532**.
+  - Scope: components depending on `ch.qos.logback` (direct or transitive) packaging of `langtool/libs`.
 
 ## 2026-06-24
 

--- a/CHANGES-WEBSPELLCHECKER.md
+++ b/CHANGES-WEBSPELLCHECKER.md
@@ -2,6 +2,12 @@
 
 This document records WebSpellChecker-specific changes on top of upstream LanguageTool.
 
+## 2026-07-14
+
+### Security
+- **jackson-databind upgrade:** Updated `jackson-databind` to **2.18.9** to address **CVE-2026-54515**.
+  - Scope: components depending on `jackson-databind` (direct or transitive) packaging of `langtool/libs`.
+
 ## 2026-06-24
 
 ### Security

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
         <org.tukaani.version>1.10</org.tukaani.version>
 
         <guava.version>33.5.0-jre</guava.version>
-        <jackson.version>2.18.8</jackson.version>
+        <jackson.version>2.18.9</jackson.version>
         <lombok.version>1.18.34</lombok.version>
         <lucene.version>5.5.5</lucene.version>
         <morfologik.version>2.2.0</morfologik.version>

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
 
         <at.favre.lib.bcrypt.version>0.10.2</at.favre.lib.bcrypt.version>
         <caffeine.version>3.2.0</caffeine.version>
-        <ch.qos.logback.version>1.5.25</ch.qos.logback.version>
+        <ch.qos.logback.version>1.5.35</ch.qos.logback.version>
 
         <com.carrotsearch.hppc.version>0.8.2</com.carrotsearch.hppc.version>
         <com.gitlab.dumonts.hunspell.version>2.1.2</com.gitlab.dumonts.hunspell.version>


### PR DESCRIPTION
Security: bump jackson-databind and logback (July 2026 CVEs)

Описание:
Security dependency bumps to clear CVEs found in langtool/libs:

- jackson-databind 2.18.8 -> 2.18.9 (CVE-2026-54515)
- logback 1.5.25 -> 1.5.35 (CVE-2026-9828, CVE-2026-10532)

Both are version-only bumps in pom.xml. Logged in CHANGES-WEBSPELLCHECKER.md.
Verified by building languagetool-standalone and re-running the dependency scan.