### PR TITLE
Security bump micrometer to 1.15.12 (CVE-2026-40984)

### DIFF
--- a/CHANGES-WEBSPELLCHECKER.md
+++ b/CHANGES-WEBSPELLCHECKER.md
@@ -2,6 +2,12 @@
 
 This document records WebSpellChecker-specific changes on top of upstream LanguageTool.
 
+## 2026-08-10
+
+### Security
+- **micrometer upgrade:** Updated `io.micrometer` to **1.15.12** to address **CVE-2026-40984**. Switched the registry dependency from `micrometer-registry-prometheus` to `micrometer-registry-prometheus-simpleclient`, which keeps the legacy `io.micrometer.prometheus` API (used by `CircuitBreakers`) on the 1.15.x line without migrating to the new Prometheus client.
+  - Scope: components depending on `micrometer-core` (direct or transitive) packaging of `langtool/libs`.
+
 ## 2026-07-24
 
 ### Security

--- a/languagetool-core/pom.xml
+++ b/languagetool-core/pom.xml
@@ -122,7 +122,7 @@
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-registry-prometheus</artifactId>
+            <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
         </dependency>
         <!-- prometheus monitoring, further dependencies in languagetool-server -->
         <!-- The client -->

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
 
         <io.prometheus.simpleclient.version>0.16.0</io.prometheus.simpleclient.version>
         <io.github.resilience4j.version>1.7.1</io.github.resilience4j.version>
-        <io.micrometer.micrometer-prometheus.version>1.7.12</io.micrometer.micrometer-prometheus.version>
+        <io.micrometer.micrometer-prometheus.version>1.15.12</io.micrometer.micrometer-prometheus.version>
         <io.opentelemetry.version>1.62.0</io.opentelemetry.version>
         <io.opentelemetry.semconv.version>1.30.1-alpha</io.opentelemetry.semconv.version>
         <io.lettuce.version>7.5.2.RELEASE</io.lettuce.version>
@@ -535,7 +535,7 @@
             </dependency>
             <dependency>
                 <groupId>io.micrometer</groupId>
-                <artifactId>micrometer-registry-prometheus</artifactId>
+                <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
                 <version>${io.micrometer.micrometer-prometheus.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
micrometer-core 1.7.12 is flagged by the scanner for CVE-2026-40984
(DoS), fixed only in 1.15.12 / 1.16.6.

Bumped io.micrometer to 1.15.12 and switched the registry dependency from
micrometer-registry-prometheus to micrometer-registry-prometheus-simpleclient.
The simpleclient variant keeps the legacy io.micrometer.prometheus API used
by CircuitBreakers, so the code compiles unchanged and we stay on the legacy
Prometheus client instead of migrating to the new one. micrometer-core is
pulled up to 1.15.12 transitively, clearing the CVE.

Logged in CHANGES-WEBSPELLCHECKER.md. Verified by building
languagetool-standalone and re-running the scan.